### PR TITLE
feat: add `pkg import` command

### DIFF
--- a/packages/radashi-helper/src/cli.ts
+++ b/packages/radashi-helper/src/cli.ts
@@ -115,6 +115,28 @@ app
   })
 
 app
+  .command('pkg [subcommand]', 'Manage your bundled dependencies')
+  .allowUnknownOptions()
+  .action(async () => {
+    const pkg = cac('radashi pkg')
+
+    pkg.option(
+      '-C, --dir <dir>',
+      'Set the directory where your Radashi is located',
+    )
+
+    pkg
+      .command('import <name>', 'Add a bundled dependency')
+      .alias('add')
+      .action(async (name: string, flags) => {
+        const { importPackage } = await import('./pkg-import')
+        await importPackage(name, flags)
+      })
+
+    await execute(pkg, app.rawArgs.slice(1))
+  })
+
+app
   .command('open [query]', 'Open function files in your editor')
   .option('-s, --source', 'Open the source file')
   .option('-t, --test', 'Open the test file (and type tests)')

--- a/packages/radashi-helper/src/env.ts
+++ b/packages/radashi-helper/src/env.ts
@@ -14,6 +14,10 @@ interface OptionalConfig {
    * The editor to use when opening a new function.
    */
   editor?: string
+  /**
+   * Packages that have been imported into the project.
+   */
+  vendor?: VendorConfig[]
 }
 
 /**
@@ -32,6 +36,34 @@ export interface UserConfig extends OptionalConfig {
    * @default ['esm']
    */
   formats?: ('esm' | 'cjs')[]
+}
+
+/**
+ * The config for a package that has been imported into the project.
+ */
+interface VendorConfig {
+  /** The name of the package. */
+  name: string
+  /**
+   * The exports to include from the package. If undefined, all
+   * exports are included.
+   *
+   * Note that type exports are also affected by this option.
+   */
+  include?: string[]
+  /**
+   * The exports to exclude from the package. If undefined, no exports
+   * are excluded.
+   *
+   * Note that type exports are also affected by this option.
+   */
+  exclude?: string[]
+  /**
+   * The exports to rename from the package. Any exports listed here
+   * are automatically added to the `include` array (if not already
+   * present).
+   */
+  rename?: Record<string, string>
 }
 
 export interface Config

--- a/packages/radashi-helper/src/pkg-import.ts
+++ b/packages/radashi-helper/src/pkg-import.ts
@@ -1,0 +1,40 @@
+import { exec } from 'exec'
+import type { CommonOptions } from './cli/options'
+import { getEnv } from './env'
+import { debug } from './util/debug'
+import { RadashiError } from './util/error'
+import { stdio } from './util/stdio'
+import { updateRadashiConfig } from './util/updateRadashiConfig'
+
+export interface ImportPackageOptions extends CommonOptions {
+  exact?: boolean
+}
+
+export async function importPackage(
+  name: string,
+  options: ImportPackageOptions = {},
+) {
+  const env = options.env ?? getEnv(options.dir)
+
+  if (env.pkg.devDependencies && name in env.pkg.devDependencies) {
+    debug(`Package '${name}' is already installed in node_modules.`)
+  } else {
+    debug(`Package '${name}' is not found in node_modules. Installing...`)
+
+    const { exitCode } = await exec('pnpm', ['install', '-D', name], {
+      cwd: env.root,
+      stdio,
+      reject: false,
+    })
+
+    if (exitCode !== 0) {
+      throw new RadashiError(
+        `Failed to install package '${name}'. See the logs above.`,
+      )
+    }
+  }
+
+  await updateRadashiConfig(env, {
+    vendor: [...(env.config.vendor ?? []), { name }],
+  })
+}


### PR DESCRIPTION
The `pkg import` command lets you incorporate an NPM package into your Radashi. You can re-export its functions, rename them, or exclude specific ones as needed.

The generated `mod.ts` module automatically includes any packages you've imported.

### Motivation

This feature is designed to help you merge your favorite NPM utility packages with Radashi, your go-to utility library. It gives you more freedom to customize Radashi to fit your needs.

### Why not just install the package directly?

Bringing trusted packages into one place has several benefits:
1. It simplifies dependency management.
2. It makes collaboration easier by establishing a clear set of recommended NPM packages for your team.
3. It allows you to use Radashi's tooling (CLI and VS Code extension) with these imported functions, which otherwise only works with native Radashi functions.
